### PR TITLE
adds a function to request a refreshtoken using auth flow

### DIFF
--- a/Cmdlet map.md
+++ b/Cmdlet map.md
@@ -68,24 +68,26 @@ New-PartnerAccessToken -Credential <App PSCredential> -RefreshToken <String> [-T
 | UseAuthorizationCode    | ❌     |
 | UseDeviceAuthentication | ❌     |
 
-### New-PartnerRefreshToken (`New-PartnerAccessToken` Web app to Refresh token)
+### New-PartnerRefreshToken (`New-PartnerAccessToken` web app to Refresh token)
 ``` pwsh
 # Old
-
+$Token = New-PartnerAccessToken -ApplicationId <String> -Scopes 'https://api.partnercenter.microsoft.com/user_impersonation' [-Tenant <String>] -UseDeviceAuthentication
 # New
-
+$Token = New-PartnerRefreshToken -ApplicationId <String> [-Scopes <String<>>] [-Tenant <String>] -Flow DeviceCode
 ```
-| Param                   | Status |
-| ----------------------- | ------ |
-| Credential              | ❌     |
-| RefreshToken            | ❌     |
-| Tenant                  | ❌     |
-| AccessToken             | ❌     |
-| ApplicationId           | ❌     |
-| CertificateThumbprint   | ❌     |
-| Environment             | ❌     |
-| Module                  | ❌     |
-| Scopes                  | ❌     |
-| ServicePrincipal        | ❌     |
-| UseAuthorizationCode    | ❌     |
-| UseDeviceAuthentication | ❌     |
+| Param                   | Status                                |
+| ----------------------- | ------------------------------------- |
+| Credential              | ❌                                    |
+| RefreshToken            | ❌                                    |
+| Tenant                  | ✔️                                  |
+| AccessToken             | ❌                                    |
+| ApplicationId           | ✔️                                  |
+| CertificateThumbprint   | ❌                                    |
+| Environment             | ❌                                    |
+| Module                  | ❌                                    |
+| Scopes                  | ✔️ Optional                         |
+| ServicePrincipal        | ❌                                    |
+| UseAuthorizationCode    | ❌ will be replaced by  `-Flow OIDC`. |
+| UseDeviceAuthentication | ❌ replaced by `-Flow DeviceCode`.    |
+| Flow                    | 🆕                                    |
+| OnlyRefreshToken        | 🆕 Return only the RefreshToken.      |

--- a/PartnerCustomerCommunity.psd1
+++ b/PartnerCustomerCommunity.psd1
@@ -79,8 +79,10 @@
         'Get-PartnerCustomerRestExample',
         'Get-PartnerOrganizationProfileRestExample',
 
+        'New-PartnerRefreshToken',
         'New-PartnerAccessToken',
         'Connect-PartnerCenter',
+
         'Get-PartnerOrganizationProfile',
         'Get-PartnerCustomer',
         'Get-PartnerCustomerSubscription',

--- a/PartnerCustomerCommunity.psm1
+++ b/PartnerCustomerCommunity.psm1
@@ -75,7 +75,7 @@ function New-PartnerRefreshToken {
         # Your CSP/Partner Center application/Client ID
         $ApplicationId,
         # Scope of the refreshtoken. Each endpoint needs its own consented refreshtoken
-        [ValidateSet("https://partner.microsoft.com//.default", 'https://api.partnercenter.microsoft.com/user_impersonation', 'https://outlook.office365.com/.default' )]
+        [ValidateSet("https://partner.microsoft.com//.default", 'https://api.partnercenter.microsoft.com/user_impersonation', 'https://outlook.office365.com/.default', 'https://management.azure.com/' )]
         $scope,
         [switch]$OnlyRefreshToken
     )

--- a/PartnerCustomerCommunity.psm1
+++ b/PartnerCustomerCommunity.psm1
@@ -87,7 +87,7 @@ function New-PartnerRefreshToken {
     }
 
     $codeRequest = Invoke-RestMethod -Method POST -Uri "https://login.microsoftonline.com/$($homeTenantID)/oauth2/v2.0/devicecode" -Body $clientBody -ErrorAction Stop
-    Write-Output "`n$($codeRequest.message)"
+    Write-Verbose "`n$($codeRequest.message)" -Verbose
 
     $tokenBody = @{
         grant_type = "urn:ietf:params:oauth:grant-type:device_code"

--- a/README.md
+++ b/README.md
@@ -45,8 +45,20 @@ Rest example Cmdlets:
 * `Get-PartnerCustomerRestExample` - Rest implementation example.
 * `Get-PartnerOrganizationProfileRestExample` - Rest implementation example.
 
+## Authentication
+https://docs.microsoft.com/en-us/partner-center/develop/enable-secure-app-model
+#### Create a web app (admin user -> web app)
+Not implemented yet, if you don't have a web app already, do manually or use ["The Script" from here](https://www.cyberdrain.com/connect-to-exchange-online-automated-when-mfa-is-enabled-using-the-secureapp-model/).
+#### Get an authorization code (web app -> authorization code)
+#### Get a refresh token (authorization code -> refresh token)
+To achieve those 2 steps you can run `New-PartnerRefreshToken`.
+#### Get an access token (refresh token -> access token).
+Use `Connect-PartnerCenter`.
+#### Make a Partner Center API call
+Just run any of the CmdLets, `Connect-PartnerCenter` holds the session credentials in the module scope.
+
 ## ToDo
-Help apriciated, open an issue to collaborate🙏
+Help appreciated, open an issue to collaborate🙏
 #### Prioritized
 * Find how to refresh the token, currently it will expire after 3 hours and it's needed to run `Connect-PartnerCenter` again.
 * Implement more Cmdlets from the PartnerCenter module.
@@ -54,6 +66,7 @@ Help apriciated, open an issue to collaborate🙏
 #### Optional
 * Add `-Output` parameter to Cmdlets.
 * Add App creation and App token refresh code if there is intrust? (code exist but need to be updated and cleaned as it uses deprecated MS modules).
+* Add `New-PartnerRefreshToken -Flow 'OIDC'` using "Pode"
 * Add GitHub Actions testing. We will probably need a "Demo" PartnerCustomer organization for this?
 * Organizing the module better, for example separate functions to different files and so.
 * Documentation.


### PR DESCRIPTION
New-PartnerRefreshToken can consume diffrerent scopes to authenticate to partnercenter or customer's exchange.

using a validate set for scope can be up for debate

``` powershell

$refreshToken = New-PartnerRefreshToken -homeTenantID $homeTenantID -ApplicationId $ApplicationId -scope https://outlook.office365.com/.default  -OnlyRefreshToken

$authBody = @{
    scope         = $scope
    refresh_token = $RefreshToken 
    grant_type    = "refresh_token"
}
$authURL = "https://login.microsoftonline.com/$customerId/oauth2/v2.0/token"
$authResponse = Invoke-RestMethod -Method POST -Uri $authURL -Body $authBody -ErrorAction Stop


$headers = @{authorization  = ('Bearer {0}' -f $authResponse.access_token)}
$users = invoke-restmethod -Uri "https://outlook.office.com/adminApi/beta/$customerID/Mailbox" -Headers $headers 